### PR TITLE
Added darwin/arm64 to get_binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ get_binaries() {
   case "$PLATFORM" in
     darwin/386) BINARIES="crypt4gh" ;;
     darwin/amd64) BINARIES="crypt4gh" ;;
+    darwin/arm64) BINARIES="crypt4gh" ;;
     linux/386) BINARIES="crypt4gh" ;;
     linux/amd64) BINARIES="crypt4gh" ;;
     windows/386) BINARIES="crypt4gh" ;;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read TrackFind's "Contributing Guideline". -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Unit/integration tests
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
The install script throws out an error when used on Macs with M1/M2 chips. The binaries seem to exist so adding darwin/arm64 to the list of obtainable binaries stops the installer from erroring out and correctly grabs and installs the binaries.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->