### PR TITLE
Update GO to v1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version: ["1.25"]
     steps:
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version: ["1.25"]
     steps:
       - name: Set up Go  ${{ matrix.go-version }}
         uses: actions/setup-go@v6
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          go get -v -t -d ./...
+          go get -v -t ./...
           if [ -f Gopkg.toml ]; then
               curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
               dep ensure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version: ["1.25"]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v6
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          go get -v -t -d ./...
+          go get -v -t ./...
           if [ -f Gopkg.toml ]; then
               curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
               dep ensure

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/crypt4gh
 
-go 1.24.0
+go 1.25.7
 
 require (
 	filippo.io/edwards25519 v1.2.0


### PR DESCRIPTION
## Description
This PR updates the GO version to `1.25`, 1.24 is EOL since mid february when 1.26 was released.